### PR TITLE
Feat/task-3: Salary model added and salary_calculator restful route added

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ curl --location 'localhost:3000/api/v1/salary_calculator/calculate' \
 - Annual Salary
 - Monthly Income Tax
 
+**Output
+```
+# Run the following cURL
+
+curl --location 'localhost:3000/api/v1/salary_calculator' \
+--header 'Content-Type: application/x-www-form-urlencoded' \
+--data-urlencode 'employee_name=ren' \
+--data-urlencode 'annual_salary=60000'
+```
+
+
 **4. Create a GET API to list out all information from Requirement 3 on JSON Format:**
 - unit tests where you think its relevant
 ```

--- a/app/controllers/api/v1/salary_calculator_controller.rb
+++ b/app/controllers/api/v1/salary_calculator_controller.rb
@@ -1,13 +1,19 @@
 class Api::V1::SalaryCalculatorController < ApplicationController
-  def calculate
+  def create
     employee_name = params[:employee_name]
     annual_salary = params[:annual_salary].to_i
 
     if employee_name.nil? || annual_salary.nil? || annual_salary < 0
       render json: { error: 'Enter valid employee name & annual salary' }, status: :bad_request
     else
-      payslip = Payslip::Generate.call(employee_name, annual_salary)
-      render json: payslip, status: :ok
+      payslip_data = Payslip::Generate.call(employee_name, annual_salary)
+      salary = Salary.new(timestamp: Time.now, employee_name: employee_name, annual_salary: annual_salary, monthly_income_tax: payslip_data[:monthly_income_tax])
+
+      if salary.save
+        render json: payslip_data, status: :ok
+      else
+        render json: {error: errors.full_messages }, status: :bad_request
+      end
     end
   end
 end

--- a/app/controllers/api/v1/salary_calculator_controller.rb
+++ b/app/controllers/api/v1/salary_calculator_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SalaryCalculatorController < ApplicationController
     employee_name = params[:employee_name]
     annual_salary = params[:annual_salary].to_i
 
-    if employee_name.nil? || annual_salary.nil? || annual_salary < 0
+    if !employee_name.present? || !annual_salary.present? || annual_salary < 0
       render json: { error: 'Enter valid employee name & annual salary' }, status: :bad_request
     else
       payslip_data = Payslip::Generate.call(employee_name, annual_salary)

--- a/app/models/salary.rb
+++ b/app/models/salary.rb
@@ -1,0 +1,2 @@
+class Salary < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      post 'salary_calculator/calculate'
+      resources :salary_calculator, only: [:create]
     end
   end
 end

--- a/db/migrate/20230321074211_create_payslips.rb
+++ b/db/migrate/20230321074211_create_payslips.rb
@@ -1,0 +1,12 @@
+class CreatePayslips < ActiveRecord::Migration[5.1]
+  def change
+    create_table :salaries do |t|
+      t.datetime :timestamp
+      t.string :employee_name, null: false
+      t.decimal :annual_salary, null: false, default: 0.0
+      t.decimal :monthly_income_tax, null: false, default: 0.0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20230321074211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "salaries", force: :cascade do |t|
+    t.datetime "timestamp"
+    t.string "employee_name", null: false
+    t.decimal "annual_salary", default: "0.0", null: false
+    t.decimal "monthly_income_tax", default: "0.0", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/controllers/api/v1/salary_calculator_controller.rb
+++ b/spec/controllers/api/v1/salary_calculator_controller.rb
@@ -1,24 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::SalaryCalculatorController, type: :controller do
-  describe 'POST #calculate' do
+  describe 'POST #create' do
     let(:employee_name) { 'John Doe' }
     
     context 'with valid parameters' do
       let(:annual_salary) { 60000 }
       
       it 'returns HTTP success' do
-        post :calculate, params: { employee_name: employee_name, annual_salary: annual_salary }
+        post :create, params: { employee_name: employee_name, annual_salary: annual_salary }
         expect(response).to have_http_status(:success)
       end
       
       it 'returns the correct JSON response' do
-        post :calculate, params: { employee_name: employee_name, annual_salary: annual_salary }
+        expect { post :create, params: { employee_name: employee_name, annual_salary: annual_salary } }.to change(Salary, :count).by(1)
         output = JSON.parse(response.body).with_indifferent_access
         expect(output[:employee_name]).to eq(employee_name)
         expect(output[:gross_monthly_income]).to eq(5000.0)
         expect(output[:monthly_income_tax]).to eq(500.0)
         expect(output[:net_monthly_income]).to eq(4500.0)
+
       end
     end
     
@@ -26,12 +27,12 @@ RSpec.describe Api::V1::SalaryCalculatorController, type: :controller do
       let(:annual_salary) { -50000 }
       
       it 'returns HTTP bad request' do
-        post :calculate, params: { employee_name: employee_name, annual_salary: annual_salary }
+        post :create, params: { employee_name: employee_name, annual_salary: annual_salary }
         expect(response).to have_http_status(:bad_request)
       end
       
       it 'returns the correct error message' do
-        post :calculate, params: { employee_name: employee_name, annual_salary: annual_salary }
+        post :create, params: { employee_name: employee_name, annual_salary: annual_salary }
         expect(JSON.parse(response.body)).to eq({
           'error' => 'Enter valid employee name & annual salary'
         })

--- a/spec/services/payslip/generate.rb
+++ b/spec/services/payslip/generate.rb
@@ -19,7 +19,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'Ren',
+          employee_name: 'Ren',
           gross_monthly_income: 5000.0,
           monthly_income_tax: 500.0,
           net_monthly_income: 4500.0
@@ -33,7 +33,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'John Doe',
+          employee_name: 'John Doe',
           gross_monthly_income: 1666.67,
           monthly_income_tax: 0.0,
           net_monthly_income: 1666.67
@@ -47,7 +47,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'Jane Smith',
+          employee_name: 'Jane Smith',
           gross_monthly_income: 2500.0,
           monthly_income_tax: 83.33,
           net_monthly_income: 2416.67
@@ -61,7 +61,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'Bob Johnson',
+          employee_name: 'Bob Johnson',
           gross_monthly_income: 5000.0,
           monthly_income_tax: 500.0,
           net_monthly_income: 4500.0
@@ -75,7 +75,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'Alice Lee',
+          employee_name: 'Alice Lee',
           gross_monthly_income: 10000.0,
           monthly_income_tax: 1833.33,
           net_monthly_income: 8166.67
@@ -89,7 +89,7 @@ RSpec.describe Payslip::Generate, type: :service do
 
       it 'returns the correct monthly payslip information' do
         expect(subject).to eq({
-          name: 'Tom Davis',
+          employee_name: 'Tom Davis',
           gross_monthly_income: 20833.33,
           monthly_income_tax: 5666.67,
           net_monthly_income: 15166.67


### PR DESCRIPTION
When compute monthly salary POST API is invoked, Then write the following information in a database of your choice, you can use any local or cloud database